### PR TITLE
Display walk distance and time under icon

### DIFF
--- a/index.html
+++ b/index.html
@@ -15,7 +15,7 @@
   h1{margin:10px 0 6px;font-size:28px}
   .sub{color:var(--muted);font-size:14px;margin-bottom:14px}
   .card{background:var(--card);border:1px solid var(--line);border-radius:14px;overflow:hidden}
-  .row{display:grid;grid-template-columns:92px 1fr 2fr 40px;gap:16px;align-items:center;padding:14px 16px}
+  .row{display:grid;grid-template-columns:92px 1fr 2fr 80px;gap:16px;align-items:center;padding:14px 16px}
   .row:nth-child(odd){background:var(--rowA)}
   .row:nth-child(even){background:var(--rowB)}
   .qr{width:72px;height:72px;border-radius:10px;border:1px solid var(--line);object-fit:cover;background:#fff}
@@ -25,7 +25,8 @@
   .details{font-size:14px;color:#2D3748}
   .details-grid{display:grid;grid-template-columns:max-content 1fr;column-gap:8px;row-gap:4px}
   .details-grid .k{font-weight:700;color:var(--muted);text-align:right}
-  .walk-col{text-align:center;font-size:20px}
+  .walk-col{text-align:center;display:flex;flex-direction:column;align-items:center;font-size:14px}
+  .walk-col .icon{font-size:20px;line-height:1}
   .hdr{display:flex;justify-content:space-between;align-items:center}
   .ver{color:#dbe7ff;font-size:12px}
   @media (max-width:820px){
@@ -45,7 +46,7 @@
 
   <div class="wrap">
     <h1>Recommended Lunch Spots</h1>
-    <div class="sub">Scan a QR to open Yelp. Order of details: Type, Description, Closest Metro, Walk distance/time, Drive time.</div>
+    <div class="sub">Scan a QR to open Yelp. Order of details: Type, Description, Closest Metro Station. Distance and walk time appear to the right.</div>
 
     <div id="list" class="card"></div>
 
@@ -56,28 +57,28 @@
 
 <script>
 const spots = [
-  {name:"City Hall Farmers Market", address:"200 N Spring St, Los Angeles, CA", rating:4.0, url:"https://www.yelp.com/biz/city-hall-farmers-market-los-angeles", type:"Various cuisines", desc:"Outdoor market with BBQ, Thai, and Mexican vendors. Wednesdays only.", metro:"Civic Center / Grand Park Station", miles:"1 mile", walkMiles:0.2, drive:"N/A"},
-  {name:"Whole Foods", address:"Los Angeles, CA", rating:4.0, url:null, type:"Healthy / Grocery", desc:"Grocery store with salad bar, hot food, and fresh options.", metro:"7th Street / Metro Center", miles:"1 mile", drive:"5 min drive"},
-  {name:"Zankou Chicken", address:"1716 S Sepulveda Blvd Los Angeles, CA 90025", rating:4.0, url:"https://www.yelp.com/biz/zankou-chicken-los-angeles-15", type:"Mediterranean", desc:"Famous for Mediterranean chicken plates and wraps.", metro:"7th Street / Metro Center", miles:"1.2 miles", drive:"6 min drive"},
-  {name:"Jollibee", address:"729 7th St, Los Angeles, CA 90017", rating:4.0, url:"https://www.yelp.com/biz/jollibee-los-angeles-6", type:"Filipino Fast Food", desc:"Fried chicken, spaghetti, and more.", metro:"7th Street / Metro Center", miles:"1.2 miles", drive:"6 min drive"},
-  {name:"Chick-fil-A", address:"660 S Figueroa St # 2300, Los Angeles, CA 90017", rating:4.0, url:"https://www.yelp.com/biz/chick-fil-a-los-angeles-23", type:"Fast Food", desc:"Chicken sandwiches and nuggets.", metro:"7th Street / Metro Center", miles:"1.2 miles", drive:"6 min drive"},
-  {name:"Mendocino Farms", address:"300 S Grand Ave Los Angeles, CA 90071", rating:4.5, url:"https://www.yelp.com/biz/mendocino-farms-los-angeles", type:"Sandwiches", desc:"Upscale sandwich shop with fresh ingredients.", metro:"7th Street / Metro Center", miles:"1.2 miles", drive:"6 min drive"},
-  {name:"MWD Cafeteria", address:"700 N Alameda St Los Angeles, CA 90012", rating:3.5, url:"https://www.yelp.com/biz/metropolitan-water-district-los-angeles-4", type:"Cafeteria", desc:"Casual cafeteria with a variety of options.", metro:"Civic Center / Grand Park Station", miles:"0.8 miles", drive:"4 min drive"},
-  {name:"Yeya's Restaurant", address:"1816 E 1st St Los Angeles, CA 90033", rating:4.5, url:"https://www.yelp.com/biz/yeyas-restaurant-los-angeles-2", type:"Mexican", desc:"Local Mexican eatery serving tacos, burritos, and more.", metro:"Civic Center / Grand Park Station", miles:"1 mile", drive:"5 min drive"},
-  {name:"Al & Bea’s", address:"2025 1st St, Los Angeles, CA 90033", rating:4.5, url:"https://www.yelp.com/biz/al-and-beas-mexican-food-los-angeles", type:"Mexican", desc:"Classic spot famous for bean and cheese burritos.", metro:"Mariachi Plaza Station", miles:"1.4 miles", drive:"7 min drive"},
-  {name:"Thai Deli", address:"1835 E Cesar E Chavez Ave Los Angeles, CA 90033", rating:4.5, url:"https://www.yelp.com/biz/thai-deli-los-angeles", type:"Thai", desc:"Authentic Thai dishes in a casual setting.", metro:"Little Tokyo / Arts District Station", miles:"1.5 miles", drive:"8 min drive"},
-  {name:"King Taco", address:"2400 E Cesar E Chavez Ave, Los Angeles, CA 90033", rating:4.0, url:"https://www.yelp.com/biz/king-taco-los-angeles-8", type:"Mexican", desc:"Popular chain with tacos, burritos, and tamales.", metro:"Soto Station", miles:"0.3 miles", drive:"7 min drive"},
-  {name:"Rice & Nori", address:"123 Astronaut E S Onizuka St Ste 103 Los Angeles, CA 90012", rating:4.5, url:"https://www.yelp.com/biz/rice-and-nori-los-angeles", type:"Japanese", desc:"Japanese rice balls and bento boxes.", metro:"Little Tokyo / Arts District Station", miles:"1.2 miles", drive:"6 min drive"},
-  {name:"Archives of Us", address:"555 N Spring St Ste 201 Los Angeles, CA 90012", rating:4.5, url:"https://www.yelp.com/biz/archives-of-us-los-angeles", type:"Café", desc:"Museum café with light bites, coffee, and pastries.", metro:"Civic Center / Grand Park Station", miles:"0.7 miles", walkMiles:0.3, drive:"N/A"},
-  {name:"Mr. Churro", address:"12 E Olvera St Los Angeles, CA 90012", rating:4.5, url:"https://www.yelp.com/biz/mr-churro-los-angeles-2", type:"Desserts / Mexican", desc:"Churros, smoothies, and tacos.", metro:"Union Station", miles:"1 mile", drive:"5 min drive"},
-  {name:"California Endowment Cafeteria", address:"1000 Alameda St, Los Angeles, CA 90012", rating:4.0, url:"https://www.yelp.com/biz/the-courtyard-caf%C3%A9-los-angeles", type:"Cafeteria", desc:"On-site cafeteria with rotating menu.", metro:"Union Station", miles:"0.8 miles", drive:"4 min drive"},
-  {name:"Grand Central Market", address:"317 S Broadway Los Angeles, CA 90013", rating:4.5, url:"https://www.yelp.com/biz/grand-central-market-los-angeles", type:"Food Hall", desc:"Historic food hall with diverse food vendors.", metro:"Pershing Square Station", miles:"1 mile", drive:"5 min drive"},
-  {name:"The Little Jewel of New Orleans", address:"207 Ord St Los Angeles, CA 90012", rating:4.5, url:"https://www.yelp.com/biz/the-little-jewel-of-new-orleans-los-angeles-3", type:"Cajun / Creole", desc:"New Orleans–style deli and grocery.", metro:"Chinatown Station", miles:"1 mile", drive:"5 min drive"},
-  {name:"Wokcano", address:"800 W 7th St Los Angeles, CA 90017", rating:4.0, url:"https://www.yelp.com/biz/wokcano-los-angeles-4", type:"Asian Fusion", desc:"Sushi, noodles, and Asian fusion plates.", metro:"Pershing Square Station", miles:"1.2 miles", drive:"6 min drive"},
-  {name:"Bottega Louie", address:"700 S Grand Ave, Los Angeles, CA 90017", rating:4.0, url:"https://www.yelp.com/biz/bottega-louie-los-angeles", type:"Italian", desc:"Upscale Italian restaurant and bakery.", metro:"Pershing Square Station", miles:"1.3 miles", drive:"6 min drive"},
-  {name:"Taco Bell Cantina", address:"801 W 7th St, Los Angeles, CA 90017", rating:4.0, url:"https://www.yelp.com/biz/taco-bell-los-angeles-77", type:"Fast Food", desc:"Taco Bell with alcohol and expanded menu.", metro:"Pershing Square Station", miles:"1.2 miles", drive:"6 min drive"},
-  {name:"Lala’s Argentine Grill", address:"7229 Melrose Ave Los Angeles, CA 90046", rating:4.5, url:"https://www.yelp.com/biz/lalas-argentine-grill-los-angeles-3", type:"Argentine", desc:"Steak, empanadas, and salads.", metro:"Westlake / MacArthur Park Station", miles:"2 miles", drive:"10 min drive"},
-  {name:"Spitz - Little Tokyo", address:"371 E 2nd St Los Angeles, CA 90012", rating:4.5, url:"https://www.yelp.com/biz/spitz-little-tokyo-los-angeles-2", type:"Mediterranean", desc:"Mediterranean street food with wraps, bowls, and craft beer.", metro:"Little Tokyo / Arts District Station", miles:"1.2 miles", drive:"6 min drive"},
+  {name:"City Hall Farmers Market", address:"200 N Spring St, Los Angeles, CA", rating:4.0, url:"https://www.yelp.com/biz/city-hall-farmers-market-los-angeles", type:"Various cuisines", desc:"Outdoor market with BBQ, Thai, and Mexican vendors. Wednesdays only.", metro:"Civic Center / Grand Park Station", miles:"1 mile", walkMiles:0.2},
+  {name:"Whole Foods", address:"Los Angeles, CA", rating:4.0, url:null, type:"Healthy / Grocery", desc:"Grocery store with salad bar, hot food, and fresh options.", metro:"7th Street / Metro Center", miles:"1 mile"},
+  {name:"Zankou Chicken", address:"1716 S Sepulveda Blvd Los Angeles, CA 90025", rating:4.0, url:"https://www.yelp.com/biz/zankou-chicken-los-angeles-15", type:"Mediterranean", desc:"Famous for Mediterranean chicken plates and wraps.", metro:"7th Street / Metro Center", miles:"1.2 miles"},
+  {name:"Jollibee", address:"729 7th St, Los Angeles, CA 90017", rating:4.0, url:"https://www.yelp.com/biz/jollibee-los-angeles-6", type:"Filipino Fast Food", desc:"Fried chicken, spaghetti, and more.", metro:"7th Street / Metro Center", miles:"1.2 miles"},
+  {name:"Chick-fil-A", address:"660 S Figueroa St # 2300, Los Angeles, CA 90017", rating:4.0, url:"https://www.yelp.com/biz/chick-fil-a-los-angeles-23", type:"Fast Food", desc:"Chicken sandwiches and nuggets.", metro:"7th Street / Metro Center", miles:"1.2 miles"},
+  {name:"Mendocino Farms", address:"300 S Grand Ave Los Angeles, CA 90071", rating:4.5, url:"https://www.yelp.com/biz/mendocino-farms-los-angeles", type:"Sandwiches", desc:"Upscale sandwich shop with fresh ingredients.", metro:"7th Street / Metro Center", miles:"1.2 miles"},
+  {name:"MWD Cafeteria", address:"700 N Alameda St Los Angeles, CA 90012", rating:3.5, url:"https://www.yelp.com/biz/metropolitan-water-district-los-angeles-4", type:"Cafeteria", desc:"Casual cafeteria with a variety of options.", metro:"Civic Center / Grand Park Station", miles:"0.8 miles"},
+  {name:"Yeya's Restaurant", address:"1816 E 1st St Los Angeles, CA 90033", rating:4.5, url:"https://www.yelp.com/biz/yeyas-restaurant-los-angeles-2", type:"Mexican", desc:"Local Mexican eatery serving tacos, burritos, and more.", metro:"Civic Center / Grand Park Station", miles:"1 mile"},
+  {name:"Al & Bea’s", address:"2025 1st St, Los Angeles, CA 90033", rating:4.5, url:"https://www.yelp.com/biz/al-and-beas-mexican-food-los-angeles", type:"Mexican", desc:"Classic spot famous for bean and cheese burritos.", metro:"Mariachi Plaza Station", miles:"1.4 miles"},
+  {name:"Thai Deli", address:"1835 E Cesar E Chavez Ave Los Angeles, CA 90033", rating:4.5, url:"https://www.yelp.com/biz/thai-deli-los-angeles", type:"Thai", desc:"Authentic Thai dishes in a casual setting.", metro:"Little Tokyo / Arts District Station", miles:"1.5 miles"},
+  {name:"King Taco", address:"2400 E Cesar E Chavez Ave, Los Angeles, CA 90033", rating:4.0, url:"https://www.yelp.com/biz/king-taco-los-angeles-8", type:"Mexican", desc:"Popular chain with tacos, burritos, and tamales.", metro:"Soto Station", miles:"0.3 miles"},
+  {name:"Rice & Nori", address:"123 Astronaut E S Onizuka St Ste 103 Los Angeles, CA 90012", rating:4.5, url:"https://www.yelp.com/biz/rice-and-nori-los-angeles", type:"Japanese", desc:"Japanese rice balls and bento boxes.", metro:"Little Tokyo / Arts District Station", miles:"1.2 miles"},
+  {name:"Archives of Us", address:"555 N Spring St Ste 201 Los Angeles, CA 90012", rating:4.5, url:"https://www.yelp.com/biz/archives-of-us-los-angeles", type:"Café", desc:"Museum café with light bites, coffee, and pastries.", metro:"Civic Center / Grand Park Station", miles:"0.7 miles", walkMiles:0.3},
+  {name:"Mr. Churro", address:"12 E Olvera St Los Angeles, CA 90012", rating:4.5, url:"https://www.yelp.com/biz/mr-churro-los-angeles-2", type:"Desserts / Mexican", desc:"Churros, smoothies, and tacos.", metro:"Union Station", miles:"1 mile"},
+  {name:"California Endowment Cafeteria", address:"1000 Alameda St, Los Angeles, CA 90012", rating:4.0, url:"https://www.yelp.com/biz/the-courtyard-caf%C3%A9-los-angeles", type:"Cafeteria", desc:"On-site cafeteria with rotating menu.", metro:"Union Station", miles:"0.8 miles"},
+  {name:"Grand Central Market", address:"317 S Broadway Los Angeles, CA 90013", rating:4.5, url:"https://www.yelp.com/biz/grand-central-market-los-angeles", type:"Food Hall", desc:"Historic food hall with diverse food vendors.", metro:"Pershing Square Station", miles:"1 mile"},
+  {name:"The Little Jewel of New Orleans", address:"207 Ord St Los Angeles, CA 90012", rating:4.5, url:"https://www.yelp.com/biz/the-little-jewel-of-new-orleans-los-angeles-3", type:"Cajun / Creole", desc:"New Orleans–style deli and grocery.", metro:"Chinatown Station", miles:"1 mile"},
+  {name:"Wokcano", address:"800 W 7th St Los Angeles, CA 90017", rating:4.0, url:"https://www.yelp.com/biz/wokcano-los-angeles-4", type:"Asian Fusion", desc:"Sushi, noodles, and Asian fusion plates.", metro:"Pershing Square Station", miles:"1.2 miles"},
+  {name:"Bottega Louie", address:"700 S Grand Ave, Los Angeles, CA 90017", rating:4.0, url:"https://www.yelp.com/biz/bottega-louie-los-angeles", type:"Italian", desc:"Upscale Italian restaurant and bakery.", metro:"Pershing Square Station", miles:"1.3 miles"},
+  {name:"Taco Bell Cantina", address:"801 W 7th St, Los Angeles, CA 90017", rating:4.0, url:"https://www.yelp.com/biz/taco-bell-los-angeles-77", type:"Fast Food", desc:"Taco Bell with alcohol and expanded menu.", metro:"Pershing Square Station", miles:"1.2 miles"},
+  {name:"Lala’s Argentine Grill", address:"7229 Melrose Ave Los Angeles, CA 90046", rating:4.5, url:"https://www.yelp.com/biz/lalas-argentine-grill-los-angeles-3", type:"Argentine", desc:"Steak, empanadas, and salads.", metro:"Westlake / MacArthur Park Station", miles:"2 miles"},
+  {name:"Spitz - Little Tokyo", address:"371 E 2nd St Los Angeles, CA 90012", rating:4.5, url:"https://www.yelp.com/biz/spitz-little-tokyo-los-angeles-2", type:"Mediterranean", desc:"Mediterranean street food with wraps, bowls, and craft beer.", metro:"Little Tokyo / Arts District Station", miles:"1.2 miles"},
 ];
 
 function yelpSearchURL(name){
@@ -120,12 +121,10 @@ function rowHTML(s){
         <div class="details-grid">
           <div class="k">Type:</div><div>${s.type}</div>
           <div class="k">Description:</div><div>${s.desc}</div>
-          <div class="k">Closest Metro:</div><div>${s.metro || 'N/A'}</div>
-          <div class="k">Walk:</div><div>${[s.miles ? (s.miles + ' from Union Station') : null, walk].filter(Boolean).join(' | ') || 'N/A'}</div>
-          <div class="k">Drive:</div><div>${s.drive || 'N/A'}</div>
+          <div class="k">Closest Metro Station:</div><div>${s.metro || 'N/A'}</div>
         </div>
       </div>
-      <div class="walk-col">${walk ? '🚶' : ''}</div>
+      <div class="walk-col">${(s.miles || walk) ? `<div class="icon">🚶</div>${s.miles ? `<div>${s.miles}</div>` : ''}${walk ? `<div>${walk}</div>` : ''}` : ''}</div>
     </div>`;
 }
 


### PR DESCRIPTION
## Summary
- Rename "Closest Metro" label to "Closest Metro Station" and drop drive information
- Show Union Station distance and walking time beneath a walk icon in a wider right-hand column
- Compute walking time from nearest station using a 3.1 mph pace

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689b7b5324cc832ba169d501ad1f3fd4