### PR TITLE
Align walking info with line logos and sort stations

### DIFF
--- a/index.html
+++ b/index.html
@@ -15,26 +15,29 @@
   h1{margin:10px 0 6px;font-size:28px}
   .sub{color:var(--muted);font-size:14px;margin-bottom:14px}
   .card{background:var(--card);border:1px solid var(--line);border-radius:14px;overflow:hidden}
-  .row{display:grid;grid-template-columns:92px 1fr 2fr 80px max-content;gap:16px;align-items:center;padding:14px 16px}
+  .row{display:grid;grid-template-columns:92px 1fr 1fr max-content;gap:16px;align-items:center;padding:14px 16px}
   .row:nth-child(odd){background:var(--rowA)}
   .row:nth-child(even){background:var(--rowB)}
   .qr{width:72px;height:72px;border-radius:10px;border:1px solid var(--line);object-fit:cover;background:#fff}
   .info .title{font-weight:700}
   .info .addr{font-size:14px;color:#2D3748;margin-top:2px}
+  .info,.details{width:100%}
   .stars{color:#FFB703;font-size:14px;margin-top:2px}
   .details{font-size:14px;color:#2D3748}
   .details-grid{display:grid;grid-template-columns:max-content 1fr;column-gap:8px;row-gap:4px}
   .details-grid .k{font-weight:700;color:var(--muted);text-align:right}
-  .walk-col{text-align:center;display:flex;flex-direction:column;align-items:center;font-size:14px}
+  .meta-col{display:flex;flex-direction:column;align-items:flex-end;text-align:right}
+  .walk-col{display:flex;flex-direction:column;align-items:flex-end;font-size:14px;margin-bottom:4px}
   .walk-col .icon{font-size:20px;line-height:1}
-  .lines-col{display:flex;gap:4px;align-items:center}
+  .lines-col{display:flex;gap:4px;align-items:center;justify-content:flex-end}
   .line-logo{width:32px;height:32px}
   .hdr{display:flex;justify-content:space-between;align-items:center}
   .ver{color:#dbe7ff;font-size:12px}
   @media (max-width:820px){
-    .row{grid-template-columns:72px 1fr;grid-template-areas:"qr info" "qr details"}
+    .row{grid-template-columns:72px 1fr;grid-template-areas:"qr info" "qr details" "qr meta"}
     .info{grid-area:info}
     .details{grid-area:details}
+    .meta-col{grid-area:meta;}
   }
 </style>
 </head>
@@ -76,13 +79,22 @@ const spots = [
   {name:"California Endowment Cafeteria", address:"1000 Alameda St, Los Angeles, CA 90012", rating:4.0, url:"https://www.yelp.com/biz/the-courtyard-caf%C3%A9-los-angeles", type:"Cafeteria", desc:"On-site cafeteria with rotating menu.", metro:"Union Station", miles:"0.3 miles"},
   {name:"Grand Central Market", address:"317 S Broadway Los Angeles, CA 90013", rating:4.5, url:"https://www.yelp.com/biz/grand-central-market-los-angeles", type:"Food Hall", desc:"Historic food hall with diverse food vendors.", metro:"Pershing Square Station", miles:"1 mile", walkMiles:0.05},
   {name:"The Little Jewel of New Orleans", address:"207 Ord St Los Angeles, CA 90012", rating:4.5, url:"https://www.yelp.com/biz/the-little-jewel-of-new-orleans-los-angeles-3", type:"Cajun / Creole", desc:"New Orleans–style deli and grocery.", metro:"Union Station", miles:"0.04 miles"},
-  {name:"Wokcano", address:"800 W 7th St Los Angeles, CA 90017", rating:4.0, url:"https://www.yelp.com/biz/wokcano-los-angeles-4", type:"Asian Fusion", desc:"Sushi, noodles, and Asian fusion plates.", metro:"7th Street / Metro Center", miles:"1.2 miles", walkMiles:0.07},
+  {name:"Wokcano", address:"800 W 7th St Los Angeles, CA 90017", rating:4.0, url:"https://www.yelp.com/biz/wokcano-los-angeles-4", type:"Asian Fusion", desc:"Sushi, noodles, and Asian fusion plates.", metro:"7th Street / Metro Center", miles:"0.07 miles", walkMiles:0.07},
   {name:"Bottega Louie", address:"700 S Grand Ave, Los Angeles, CA 90017", rating:4.0, url:"https://www.yelp.com/biz/bottega-louie-los-angeles", type:"Italian", desc:"Upscale Italian restaurant and bakery.", metro:"Pershing Square Station", miles:"1.3 miles", walkMiles:0.4},
   {name:"Taco Bell Cantina", address:"801 W 7th St, Los Angeles, CA 90017", rating:4.0, url:"https://www.yelp.com/biz/taco-bell-los-angeles-77", type:"Fast Food", desc:"Taco Bell with alcohol and expanded menu.", metro:"7th Street / Metro Center", miles:"1.2 miles", walkMiles:0.08},
-  {name:"Lala’s Argentine Grill", address:"105 W 9th St, Los Angeles, CA 90015", rating:4.5, url:"https://www.yelp.com/biz/lalas-argentine-grill-los-angeles-3", type:"Argentine", desc:"Steak, empanadas, and salads.", metro:"Main / 9th", miles:"1 mile", walkMiles:0.3},
+  {name:"Lala’s Argentine Grill", address:"105 W 9th St, Los Angeles, CA 90015", rating:4.5, url:"https://www.yelp.com/biz/lalas-argentine-grill-los-angeles-3", type:"Argentine", desc:"Steak, empanadas, and salads.", metro:"Bus line 28 - Main / 9th", miles:"1 mile", walkMiles:0.3},
   {name:"Spitz - Little Tokyo", address:"371 E 2nd St Los Angeles, CA 90012", rating:4.5, url:"https://www.yelp.com/biz/spitz-little-tokyo-los-angeles-2", type:"Mediterranean", desc:"Mediterranean street food with wraps, bowls, and craft beer.", metro:"Little Tokyo / Arts District Station", miles:"1.2 miles", walkMiles:0.3},
 
 
+];
+
+const stationOrder = [
+  "Union Station",
+  "7th Street / Metro Center",
+  "Little Tokyo / Arts District Station",
+  "Pershing Square Station",
+  "Mariachi Plaza Station",
+  "Bus lines"
 ];
 
 const stationLines = {
@@ -94,6 +106,12 @@ const stationLines = {
   "Little Tokyo / Arts District Station": ["A","E"],
   "Chinatown Station": ["A"]
 };
+
+function stationIdx(s){
+  if(s.metro && s.metro.startsWith("Bus line")) return stationOrder.indexOf("Bus lines");
+  const idx = stationOrder.indexOf(s.metro);
+  return idx === -1 ? stationOrder.length : idx;
+}
 
 function yelpSearchURL(name){
   // Yelp search pointing to Los Angeles; easy to replace with exact business URLs later
@@ -121,6 +139,9 @@ function walkTime(miles){
 }
 
 function lineLogosHTML(station){
+  if(station === "Union Station"){
+    return `<div class="lines-col"><img class="line-logo" src="metro-line-logos/union-station-logo.png" alt="Union Station" /></div>`;
+  }
   const lines = stationLines[station];
   const logos = lines ? lines.map(l => `<img class="line-logo" src="metro-line-logos/${l.toLowerCase()}-line-logo.png" alt="${l} Line" />`).join("") : "";
   return `<div class="lines-col">${logos}</div>`;
@@ -144,15 +165,20 @@ function rowHTML(s){
           <div class="k">Closest Metro Station:</div><div>${s.metro || 'N/A'}</div>
         </div>
       </div>
-      <div class="walk-col">${(s.miles || walk) ? `<div class="icon">🚶</div>${s.miles ? `<div>${s.miles}</div>` : ''}${walk ? `<div>${walk}</div>` : ''}` : ''}</div>
-      ${lineLogosHTML(s.metro)}
+      <div class="meta-col">
+        ${(s.miles || walk) ? `<div class="walk-col"><div class="icon">🚶</div>${s.miles ? `<div>${s.miles}</div>` : ''}${walk ? `<div>${walk}</div>` : ''}</div>` : ''}
+        ${lineLogosHTML(s.metro)}
+      </div>
     </div>`;
 }
 
 document.getElementById("list").innerHTML =
   spots
     .slice()
-    .sort((a,b)=>a.name.localeCompare(b.name))
+    .sort((a,b)=>{
+      const diff = stationIdx(a) - stationIdx(b);
+      return diff !== 0 ? diff : a.name.localeCompare(b.name);
+    })
     .map(rowHTML)
     .join("");
 </script>


### PR DESCRIPTION
## Summary
- Display walking distance above station logos and align to the right.
- Sort lunch spots by metro station priority and update data for Wokcano and Lala’s Argentine Grill.
- Show Union Station logo for Union Station entries.

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a63c30e8a0832b829fb43307091096