### PR TITLE
Round walk distance calculation to two decimals

### DIFF
--- a/index.html
+++ b/index.html
@@ -134,7 +134,9 @@ function starHTML(r){
 
 function walkTime(miles){
   if(miles == null) return null;
-  const mins = Math.round(miles / 3.1 * 60);
+  // round miles to two decimal places to avoid overly precise values
+  const roundedMiles = Math.round(miles * 100) / 100;
+  const mins = Math.round(roundedMiles / 3.1 * 60);
   return `${mins} min walk`;
 }
 


### PR DESCRIPTION
## Summary
- Round walk distance to two decimal places before converting to walking time.

## Testing
- `npm test` *(fails: /usr/bin/npm: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68a63ecb23d0832bb79b55fedf461735